### PR TITLE
squelch countrycode warnings when no currency is matched

### DIFF
--- a/R/prepare_iss_average_sector_emission_intensities.R
+++ b/R/prepare_iss_average_sector_emission_intensities.R
@@ -38,7 +38,7 @@ prepare_iss_average_sector_emission_intensities <- function(iss_company_emission
     factset_entity_financing_data %>%
     dplyr::left_join(factset_entity_info, by = "factset_entity_id") %>%
     dplyr::filter(
-      countrycode::countrycode(.data[["iso_country"]], "iso2c", "iso4217c") == .data[["currency"]]
+      countrycode::countrycode(.data[["iso_country"]], "iso2c", "iso4217c", warn = FALSE) == .data[["currency"]]
     ) %>%
     dplyr::left_join(currencies, by = "currency") %>%
     dplyr::mutate(

--- a/R/prepare_iss_entity_emission_intensities.R
+++ b/R/prepare_iss_entity_emission_intensities.R
@@ -37,7 +37,7 @@ prepare_iss_entity_emission_intensities <- function(iss_company_emissions,
   factset_entity_financing_data %>%
     dplyr::left_join(factset_entity_info, by = "factset_entity_id") %>%
     dplyr::filter(
-      countrycode::countrycode(.data[["iso_country"]], "iso2c", "iso4217c") == .data[["currency"]]
+      countrycode::countrycode(.data[["iso_country"]], "iso2c", "iso4217c", warn = FALSE) == .data[["currency"]]
     ) %>%
     dplyr::left_join(currencies, by = "currency") %>%
     dplyr::mutate(


### PR DESCRIPTION
in particular, when the country code is `PS` and there's no matching currency code

``` r
countrycode::countrycode("PS", "iso2c", "iso4217c")
#> Warning: Some values were not matched unambiguously: PS
#> [1] NA
```

``` r
countrycode::countrycode("PS", "iso2c", "iso4217c", warn = FALSE)
#> [1] NA
```

⚠️ I'm not 100% sure it's appropriate to ignore *all/any* warning here